### PR TITLE
hotfix(pages): replace buttons in auth page to Button component

### DIFF
--- a/src/components/layouts/AuthLayout/styled.ts
+++ b/src/components/layouts/AuthLayout/styled.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 export const AuthLayoutContainer = styled.div`
   width: 100%;
-  height: 100%;
+  min-height: 100%;
 `;
 
 export const AuthLayoutWrapper = styled.main`

--- a/src/pages/auth/signin/index.tsx
+++ b/src/pages/auth/signin/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
-import { Input } from '@/components';
+import { Button, Input } from '@/components';
 import { useAuth } from '@/providers';
 
 import * as S from './styled';
@@ -59,7 +59,7 @@ export const SignInPage: React.FC = () => {
           <span>|</span>
           <Link to="/auth/forgot-password">비밀번호 찾기</Link>
         </S.SignInLinkContainer>
-        <button type="submit">로그인</button>
+        <Button type="submit">로그인</Button>
       </S.SignInContainer>
     </S.SignInForm>
   );

--- a/src/pages/auth/signup/index.tsx
+++ b/src/pages/auth/signup/index.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
 import { SCHOOL } from '@/constant';
-import { Input } from '@/components';
+import { Button, Input } from '@/components';
 import { useAuth } from '@/providers';
 
 import * as S from './styled';
@@ -216,9 +216,9 @@ export const SignUpPage: React.FC = () => {
         <S.SignUpLinkContainer>
           이미 계정이 있으신가요? <Link to="/auth/signin">로그인</Link>
         </S.SignUpLinkContainer>
-        <button type="submit" disabled={!isAllValuesEntered}>
-          가입하기
-        </button>
+        <Button type="submit" disabled={!isAllValuesEntered}>
+          회원가입
+        </Button>
       </S.SignUpContainer>
     </S.SignUpForm>
   );


### PR DESCRIPTION
## 🔍 What is this PR?
- 로그인/회원가입 페이지 내 기본 버튼들을 모두 `Button` 컴포넌트로 교체했어요
- `AuthLayout`에서 window height이 좁아지는 경우 `Footer`와 겹치는 문제를 해결했어요

## 📸 스크린 샷
**어떤 점이 달라졌는지 알 수 있게끔 스크린 샷을 첨부해주세요.**

## ✅ 체크 리스트
- [ ]  **테스트 계획 또는 완료된 사항의 체크리스트를 작성해주세요.**