### PR TITLE
fix(components): disable MainSection cricles for mobile support

### DIFF
--- a/src/components/main/MainSection/index.tsx
+++ b/src/components/main/MainSection/index.tsx
@@ -9,34 +9,36 @@ export const MainSection: React.FC = () => {
 
   return (
     <BlurCircle.Section
-      circles={[
-        {
-          width: 110,
-          height: 50,
-          animate: {
-            x: [230, -30, 230],
-            y: [0, -100, -80, 0],
-            backgroundColor: [
-              'rgba(87, 60, 255, 0.07)',
-              'rgba(87, 60, 255, 0.1)',
-              'rgba(87, 60, 255, 0.07)',
-            ],
-          },
-        },
-        {
-          width: 80,
-          height: 40,
-          animate: {
-            x: [-300, 0, -300],
-            y: [300, 200, 300],
-            backgroundColor: [
-              'rgba(177, 41, 241, 0.07)',
-              'rgba(177, 41, 241, 0.1)',
-              'rgba(177, 41, 241, 0.07)',
-            ],
-          },
-        },
-      ]}
+      circles={
+        [
+          // {
+          //   width: 110,
+          //   height: 50,
+          //   animate: {
+          //     x: [230, -30, 230],
+          //     y: [0, -100, -80, 0],
+          //     backgroundColor: [
+          //       'rgba(87, 60, 255, 0.07)',
+          //       'rgba(87, 60, 255, 0.1)',
+          //       'rgba(87, 60, 255, 0.07)',
+          //     ],
+          //   },
+          // },
+          // {
+          //   width: 80,
+          //   height: 40,
+          //   animate: {
+          //     x: [-300, 0, -300],
+          //     y: [300, 200, 300],
+          //     backgroundColor: [
+          //       'rgba(177, 41, 241, 0.07)',
+          //       'rgba(177, 41, 241, 0.1)',
+          //       'rgba(177, 41, 241, 0.07)',
+          //     ],
+          //   },
+          // },
+        ]
+      }
     >
       <Text.Column {...animation}>
         <Text.Row>


### PR DESCRIPTION
## 🔍 What is this PR?
- 모바일 환경에서 `BlurCircle`의 애니메이션으로 `overflow-x` 값이 증가하는 문제가 발생했어요
   임시로 해결하기 위해 `BlurCircle`을 모두 주석처리 했어요

## 📸 스크린 샷
**어떤 점이 달라졌는지 알 수 있게끔 스크린 샷을 첨부해주세요.**

## ✅ 체크 리스트
- [ ]  **테스트 계획 또는 완료된 사항의 체크리스트를 작성해주세요.**